### PR TITLE
refactor: change connection URL response to plain string

### DIFF
--- a/internal/server/router/connection.go
+++ b/internal/server/router/connection.go
@@ -36,7 +36,7 @@ func (cr *ConnectionRouter) Get(ctx *gin.Context) {
 	}
 
 	if conn.Status.Phase == tfv1.TensorFusionConnectionRunning {
-		ctx.JSON(200, conn.Status.ConnectionURL)
+		ctx.String(200, conn.Status.ConnectionURL)
 		return
 	}
 
@@ -47,7 +47,7 @@ func (cr *ConnectionRouter) Get(ctx *gin.Context) {
 	// Wait for connection updates
 	for conn := range ch {
 		if conn.Status.Phase == tfv1.TensorFusionConnectionRunning {
-			ctx.JSON(200, conn.Status.ConnectionURL)
+			ctx.String(200, conn.Status.ConnectionURL)
 			return
 		}
 	}


### PR DESCRIPTION
Modify connection endpoint to return connection URL as plain text instead of JSON format for better client compatibility